### PR TITLE
Handle zero union area in IoU computation

### DIFF
--- a/eval_fianl/eval_utils.py
+++ b/eval_fianl/eval_utils.py
@@ -12,7 +12,10 @@ def computeIoU(bbox1, bbox2, return_iou=False):
     bbox1_area = (x2 - x1 + 1) * (y2 - y1 + 1)
     bbox2_area = (x4 - x3 + 1) * (y4 - y3 + 1)
     union_area = bbox1_area + bbox2_area - intersection_area
-    iou = intersection_area / union_area
+    if union_area <= 0:
+        iou = 0.0
+    else:
+        iou = intersection_area / union_area
     if return_iou:
         return iou, intersection_area, union_area
     else:


### PR DESCRIPTION
## Summary
- avoid division by zero in IoU calculation when bounding boxes have zero or negative area

## Testing
- `python -m py_compile eval_fianl/eval_utils.py`
- `python - <<'PY'
import types, sys
sys.modules['numpy'] = types.SimpleNamespace()
from eval_fianl.eval_utils import computeIoU
print(computeIoU((1,1,0,0),(2,2,1,1)))
PY`

------
https://chatgpt.com/codex/tasks/task_e_689c90fd04548332a0a4ed95b0eb14cc